### PR TITLE
Allow running in daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Then you can access the service at
 - `http://<your server address>:<REDISEEN_PORT>/<redis DB>/<key>`
 - `http://<your server address>:<REDISEEN_PORT>/<redis DB>/<key>/<index or value or member>`
 
+If you would like to run the service in daemon mode, apply flag `-d`.
+
+```bash
+# run service in daemon mode
+rediseen -d start
+
+# stop service running in daemon mode
+rediseen stop
+```
+
 
 ### 2.4 How to Consume the Service
 

--- a/actions.go
+++ b/actions.go
@@ -113,15 +113,10 @@ func validateDbExposeConfig(configDbExposed string) (bool, error) {
 	log.Println(fmt.Sprintf("[INFO] You are exposing logical database(s) `%s`", configDbExposed))
 
 	// case-2: "0" or "18"
-	patternCheck1, err := regexp.MatchString("^[0-9]+$", configDbExposed)
-	if err != nil {
-		return false, err
-	}
+	patternCheck1, _ := regexp.MatchString("^[0-9]+$", configDbExposed)
+
 	// case-3: "0-10" or "0;0-10" or "1-10;13"
-	patternCheck2, err := regexp.MatchString("(^[0-9]+)([0-9;-]*)([0-9]+$)", configDbExposed)
-	if err != nil {
-		return false, err
-	}
+	patternCheck2, _ := regexp.MatchString("(^[0-9]+)([0-9;-]*)([0-9]+$)", configDbExposed)
 
 	if !patternCheck1 && !patternCheck2 {
 		return false, errors.New("illegal pattern")

--- a/constants.go
+++ b/constants.go
@@ -6,7 +6,7 @@ const defaultPort = "8000"
 const strNotImplemented = "not implemented"
 const strWrongTypeForIndexField = "wrong type for index/field"
 
-const strUsage = "Usage: rediseen [start/help/version]"
+const strUsage = "Usage: rediseen [start/stop/help/version]"
 
 const strHelpDoc = "\n\n" + strUsage + "\n\n" +
 	"Configuration Items (via environment variables):\n" +

--- a/constants.go
+++ b/constants.go
@@ -6,7 +6,7 @@ const defaultPort = "8000"
 const strNotImplemented = "not implemented"
 const strWrongTypeForIndexField = "wrong type for index/field"
 
-const strUsage = "Usage: rediseen [start/stop/help/version]"
+const strUsage = "Usage: rediseen [-d] [start/stop/help/version]"
 
 const strHelpDoc = "\n\n" + strUsage + "\n\n" +
 	"Configuration Items (via environment variables):\n" +

--- a/constants.go
+++ b/constants.go
@@ -8,7 +8,7 @@ const strWrongTypeForIndexField = "wrong type for index/field"
 
 const strUsage = "Usage: rediseen [-d] [start/stop/help/version]"
 
-const strHelpDoc = "\n\n" + strUsage + "\n\n" +
+const strHelpDoc = "\n" + strUsage + "\n\nFlag:\n-d: run in background\n\n" +
 	"Configuration Items (via environment variables):\n" +
 	"- REDISEEN_REDIS_URI: URI of your Redis database, e.g. `redis://:@localhost:6379`\n" +
 	"- REDISEEN_HOST: host of the service. Default port is 'localhost'\n" +

--- a/rediseen.go
+++ b/rediseen.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 )
 
@@ -63,7 +64,7 @@ func main() {
 	fmt.Println(strHeader)
 
 	var daemon = flag.Bool("d", false, "Run in daemon mode")
-	var pidFile = flag.String("pidfile", "/tmp/rediseen.pid", "where PID is stored for daemon mode")
+	var pidFile = flag.String("pidfile", path.Join(os.TempDir(), "rediseen.pid"), "where PID is stored for daemon mode")
 	flag.Parse()
 
 	args := flag.Args()

--- a/rediseen.go
+++ b/rediseen.go
@@ -13,6 +13,9 @@ import (
 	"strconv"
 )
 
+var daemon = flag.Bool("d", false, "Run in daemon mode")
+var pidFile = flag.String("pidfile", path.Join(os.TempDir(), "rediseen.pid"), "where PID is stored for daemon mode")
+
 func savePID(pid int, fileForPid string) error {
 
 	file, err := os.Create(fileForPid)
@@ -32,11 +35,7 @@ func savePID(pid int, fileForPid string) error {
 }
 
 func stopDaemon(fileForPid string) error {
-	if _, err := os.Stat(fileForPid); err == nil {
-		rawPid, err := ioutil.ReadFile(fileForPid)
-		if err != nil {
-			return errors.New("no running service found")
-		}
+	if rawPid, err := ioutil.ReadFile(fileForPid); err == nil {
 		pid, err := strconv.Atoi(string(rawPid))
 		if err != nil {
 			return errors.New(fmt.Sprintf("Invalid PID found in %s", fileForPid))
@@ -56,15 +55,13 @@ func stopDaemon(fileForPid string) error {
 			return nil
 		}
 	} else {
-		return errors.New(fmt.Sprintf("no running service found"))
+		return errors.New("no running service found")
 	}
 }
 
 func main() {
 	fmt.Println(strHeader)
 
-	var daemon = flag.Bool("d", false, "Run in daemon mode")
-	var pidFile = flag.String("pidfile", path.Join(os.TempDir(), "rediseen.pid"), "where PID is stored for daemon mode")
 	flag.Parse()
 
 	args := flag.Args()

--- a/rediseen.go
+++ b/rediseen.go
@@ -66,7 +66,7 @@ func main() {
 	args := flag.Args()
 	if len(args) != 1 {
 		fmt.Println(strUsage)
-		os.Exit(0)
+		return
 	}
 
 	switch args[0] {

--- a/rediseen.go
+++ b/rediseen.go
@@ -6,16 +6,16 @@ import (
 	"log"
 	"net/http"
 	"os"
-	//"os"
+	"os/exec"
 )
 
 func main() {
 	fmt.Println(strHeader)
 
-	var command = flag.Bool("d", false, "Run in daemon mode")
+	var daemon = flag.Bool("d", false, "Run in daemon mode")
 	flag.Parse()
 
-	fmt.Println("Daemon mode:", *command)
+	fmt.Println("Daemon mode:", *daemon)
 
 	args := flag.Args()
 	if len(args) != 1 {
@@ -29,6 +29,17 @@ func main() {
 		if err != nil {
 			fmt.Println("[ERROR] " + err.Error())
 			return
+		}
+
+		if *daemon {
+			cmd := exec.Command(os.Args[0], args...)
+			err = cmd.Start()
+			if err != nil {
+				fmt.Println("[ERROR] " + err.Error())
+				return
+			}
+			log.Println("[INFO] Running in daemon. PID:", cmd.Process.Pid)
+			os.Exit(0)
 		}
 
 		http.HandleFunc("/", service)

--- a/rediseen.go
+++ b/rediseen.go
@@ -41,16 +41,16 @@ func stopDaemon(fileForPid string) error {
 			return errors.New(fmt.Sprintf("Invalid PID found in %s", fileForPid))
 		}
 
+		os.Remove(fileForPid)
+
 		process, err := os.FindProcess(pid)
 		if err != nil {
-			return errors.New(fmt.Sprintf("Unable to find PID [%v] (error: %v)\n", pid, err.Error()))
+			return errors.New(fmt.Sprintf("Unable to find PID %v (error: %v)\n", pid, err.Error()))
 		}
-
-		os.Remove(fileForPid)
 
 		err = process.Kill()
 		if err != nil {
-			return errors.New(fmt.Sprintf("Unable to kill process [%v] (error: %v)\n", pid, err.Error()))
+			return errors.New(fmt.Sprintf("Unable to kill process %v (error: %v)\n", pid, err.Error()))
 		} else {
 			return nil
 		}
@@ -116,6 +116,8 @@ func main() {
 		err := stopDaemon(*pidFile)
 		if err != nil {
 			fmt.Println(err.Error())
+		} else {
+			fmt.Println("Service running in daemon is stopped.")
 		}
 	case "help":
 		fmt.Println(strHelpDoc)

--- a/rediseen.go
+++ b/rediseen.go
@@ -3,19 +3,40 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 )
+
+var pidFile = "/tmp/rediseen.pid"
+
+func savePID(pid int) {
+
+	file, err := os.Create(pidFile)
+	if err != nil {
+		log.Printf("Unable to create pid file : %v\n", err)
+		os.Exit(1)
+	}
+
+	defer file.Close()
+
+	_, err = file.WriteString(strconv.Itoa(pid))
+	if err != nil {
+		log.Printf("Unable to create pid file : %v\n", err)
+		os.Exit(1)
+	}
+
+	file.Sync() // flush to disk
+}
 
 func main() {
 	fmt.Println(strHeader)
 
 	var daemon = flag.Bool("d", false, "Run in daemon mode")
 	flag.Parse()
-
-	fmt.Println("Daemon mode:", *daemon)
 
 	args := flag.Args()
 	if len(args) != 1 {
@@ -25,6 +46,8 @@ func main() {
 
 	switch args[0] {
 	case "start":
+		fmt.Println("Daemon mode:", *daemon)
+
 		err := configCheck()
 		if err != nil {
 			fmt.Println("[ERROR] " + err.Error())
@@ -32,6 +55,12 @@ func main() {
 		}
 
 		if *daemon {
+			// check if daemon already running.
+			if _, err := os.Stat(pidFile); err == nil {
+				fmt.Println(fmt.Sprintf("Already running or %s file exist.", pidFile))
+				os.Exit(1)
+			}
+
 			cmd := exec.Command(os.Args[0], args...)
 			err = cmd.Start()
 			if err != nil {
@@ -39,16 +68,56 @@ func main() {
 				return
 			}
 			log.Println("[INFO] Running in daemon. PID:", cmd.Process.Pid)
+			savePID(cmd.Process.Pid)
 			os.Exit(0)
 		}
 
 		http.HandleFunc("/", service)
 
 		addr := generateAddr()
-		log.Printf("Serving at %s", addr)
+		log.Printf("[INFO] Serving at %s", addr)
 		serve := http.ListenAndServe(addr, nil)
 		if serve != nil {
-			panic(serve)
+			log.Println("[ERROR] Failed to launch. Details: ", serve.Error())
+		}
+	case "stop":
+		if _, err := os.Stat(pidFile); err == nil {
+			data, err := ioutil.ReadFile(pidFile)
+			if err != nil {
+				fmt.Println("Not running")
+				os.Exit(1)
+			}
+			ProcessID, err := strconv.Atoi(string(data))
+
+			if err != nil {
+				fmt.Println("Unable to read and parse process id found in ", pidFile)
+				os.Exit(1)
+			}
+
+			process, err := os.FindProcess(ProcessID)
+
+			if err != nil {
+				fmt.Printf("Unable to find process ID [%v] with error %v \n", ProcessID, err)
+				os.Exit(1)
+			}
+			// remove PID file
+			os.Remove(pidFile)
+
+			fmt.Printf("Killing process ID [%v] now.\n", ProcessID)
+			// kill process and exit immediately
+			err = process.Kill()
+
+			if err != nil {
+				fmt.Printf("Unable to kill process ID [%v] with error %v \n", ProcessID, err)
+				os.Exit(1)
+			} else {
+				fmt.Printf("Killed process ID [%v]\n", ProcessID)
+				os.Exit(0)
+			}
+
+		} else {
+			fmt.Println("Not running.")
+			os.Exit(1)
 		}
 	case "help":
 		fmt.Println(strHelpDoc)

--- a/rediseen.go
+++ b/rediseen.go
@@ -88,7 +88,7 @@ func main() {
 		if *daemon {
 			// check if daemon already running.
 			if _, err := os.Stat(pidFile); err == nil {
-				fmt.Println(fmt.Sprintf("Already running or %s file exist.", pidFile))
+				fmt.Println(fmt.Sprintf("[ERROR] Already running or file %s exist.", pidFile))
 				os.Exit(1)
 			}
 

--- a/rediseen.go
+++ b/rediseen.go
@@ -63,7 +63,6 @@ func main() {
 	fmt.Println(strHeader)
 
 	flag.Parse()
-
 	args := flag.Args()
 	if len(args) != 1 {
 		fmt.Println(strUsage)

--- a/rediseen.go
+++ b/rediseen.go
@@ -18,7 +18,7 @@ func savePID(pid int, fileForPid string) {
 
 	file, err := os.Create(fileForPid)
 	if err != nil {
-		log.Printf("Unable to create pid file : %v\n", err)
+		log.Printf("Unable to create PID file : %v\n", err)
 		os.Exit(1)
 	}
 
@@ -26,7 +26,7 @@ func savePID(pid int, fileForPid string) {
 
 	_, err = file.WriteString(strconv.Itoa(pid))
 	if err != nil {
-		log.Printf("Unable to create PID file : %v\n", err)
+		log.Printf("Unable to write to PID file : %v\n", err)
 		os.Exit(1)
 	}
 
@@ -55,9 +55,8 @@ func stopDaemon(fileForPid string) error {
 		if err != nil {
 			return errors.New(fmt.Sprintf("Unable to kill process [%v] (error: %v)\n", pid, err.Error()))
 		} else {
-			return errors.New(fmt.Sprintf("Killed process [%v]\n", pid))
+			return nil
 		}
-
 	} else {
 		return errors.New(fmt.Sprintf("Not running"))
 	}

--- a/rediseen.go
+++ b/rediseen.go
@@ -17,14 +17,14 @@ func savePID(pid int, fileForPid string) error {
 
 	file, err := os.Create(fileForPid)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Unable to create PID file: %v\n", err))
+		return errors.New(fmt.Sprintf("Unable to create PID file: %s", err.Error()))
 	}
 
 	defer file.Close()
 
 	_, err = file.WriteString(strconv.Itoa(pid))
 	if err != nil {
-		return errors.New(fmt.Sprintf("Unable to write to PID file : %v\n", err))
+		return errors.New(fmt.Sprintf("Unable to write to PID file : %s", err.Error()))
 	}
 
 	file.Sync() // flush to disk
@@ -46,12 +46,12 @@ func stopDaemon(fileForPid string) error {
 
 		process, err := os.FindProcess(pid)
 		if err != nil {
-			return errors.New(fmt.Sprintf("Unable to find PID %v (error: %v)\n", pid, err.Error()))
+			return errors.New(fmt.Sprintf("Unable to find PID %d (error: %s)", pid, err.Error()))
 		}
 
 		err = process.Kill()
 		if err != nil {
-			return errors.New(fmt.Sprintf("Unable to kill process %v (error: %v)\n", pid, err.Error()))
+			return errors.New(fmt.Sprintf("Unable to kill process %d (error: %s)", pid, err.Error()))
 		} else {
 			return nil
 		}

--- a/rediseen.go
+++ b/rediseen.go
@@ -1,21 +1,29 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	//"os"
 )
 
 func main() {
 	fmt.Println(strHeader)
 
-	if len(os.Args) != 2 {
+	var command = flag.Bool("d", false, "Run in daemon mode")
+	flag.Parse()
+
+	fmt.Println("Daemon mode:", *command)
+
+	args := flag.Args()
+	if len(args) != 1 {
 		fmt.Println(strUsage)
 		os.Exit(0)
 	}
 
-	switch os.Args[1] {
+	switch args[0] {
 	case "start":
 		err := configCheck()
 		if err != nil {

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -60,17 +60,21 @@ func Test_stopDaemon_normal(t *testing.T) {
 	if err != nil {
 		t.Error("Expecting nil \ngot\n", err)
 	}
+
+	process, _ := os.FindProcess(cmd.Process.Pid)
+	status, _ := process.Wait()
+	compareAndShout(t, "signal: killed", status.String())
 }
 
 func Test_Main(t *testing.T) {
 	// First element "" is a placeholder for executable
 	//ref: https://stackoverflow.com/a/48674736
 
-	// "rediseen"
+	// command "rediseen"
 	os.Args = []string{""}
 	main()
 
-	// "rediseen version", "rediseen help", "rediseen stop", "rediseen wrong_command"
+	// commands "rediseen version", "rediseen help", "rediseen stop", "rediseen wrong_command"
 	for _, command := range []string{"version", "help", "stop", "wrong_command"} {
 		os.Args = []string{"", command}
 		main()

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -4,13 +4,20 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
+
+func Test_savePID(t *testing.T) {
+	testPidFileLocation := "/xxx/yyy.pid"
+	err := savePID(100, testPidFileLocation)
+	compareAndShout(t, "Unable to create PID file", strings.Split(err.Error(), ":")[0])
+}
 
 func Test_stopDaemon_no_pid_file(t *testing.T) {
 	err := stopDaemon("/tmp/non-existing")
 
-	compareAndShout(t, "Not running", err.Error())
+	compareAndShout(t, "no running service found", err.Error())
 }
 
 func Test_stopDaemon_invalid_pid(t *testing.T) {

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -61,3 +61,14 @@ func Test_stopDaemon_normal(t *testing.T) {
 		t.Error("Expecting nil \ngot\n", err)
 	}
 }
+
+func Test_Main(t *testing.T) {
+	os.Args = []string{"", "version"}
+	main()
+
+	os.Args = []string{"", "help"}
+	main()
+
+	os.Args = []string{"", "stop"}
+	main()
+}

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -63,12 +63,13 @@ func Test_stopDaemon_normal(t *testing.T) {
 }
 
 func Test_Main(t *testing.T) {
-	os.Args = []string{"", "version"}
+	// First element "" is a placeholder for executable
+	//ref: https://stackoverflow.com/a/48674736
+	os.Args = []string{""}
 	main()
 
-	os.Args = []string{"", "help"}
-	main()
-
-	os.Args = []string{"", "stop"}
-	main()
+	for _, command := range []string{"version", "help", "stop", ""} {
+		os.Args = []string{"", command}
+		main()
+	}
 }

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -65,10 +65,13 @@ func Test_stopDaemon_normal(t *testing.T) {
 func Test_Main(t *testing.T) {
 	// First element "" is a placeholder for executable
 	//ref: https://stackoverflow.com/a/48674736
+
+	// "rediseen"
 	os.Args = []string{""}
 	main()
 
-	for _, command := range []string{"version", "help", "stop", ""} {
+	// "rediseen version", "rediseen help", "rediseen stop", "rediseen wrong_command"
+	for _, command := range []string{"version", "help", "stop", "wrong_command"} {
 		os.Args = []string{"", command}
 		main()
 	}

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func Test_stopDaemon_no_pid_file(t *testing.T) {
+	err := stopDaemon("/tmp/non-existing")
+
+	compareAndShout(t, "Not running", err.Error())
+}
+
+func Test_stopDaemon_invalid_pid(t *testing.T) {
+
+	testPidFileLocation := "/tmp/temptesting.pid"
+
+	file, err := os.Create(testPidFileLocation)
+	if err != nil {
+		log.Printf("Unable to create PID file : %v\n", err)
+		os.Exit(1)
+	}
+
+	defer file.Close()
+
+	_, err = file.WriteString("invalid PID")
+	if err != nil {
+		log.Printf("Unable to create PID file : %v\n", err)
+		os.Exit(1)
+	}
+
+	file.Sync()
+
+	err = stopDaemon(testPidFileLocation)
+
+	compareAndShout(t, "Invalid PID found in "+testPidFileLocation, err.Error())
+}

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -60,5 +60,4 @@ func Test_stopDaemon_normal(t *testing.T) {
 	if err != nil {
 		t.Error("Expecting nil \ngot\n", err)
 	}
-
 }

--- a/rediseen_test.go
+++ b/rediseen_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -15,6 +16,7 @@ func Test_stopDaemon_no_pid_file(t *testing.T) {
 func Test_stopDaemon_invalid_pid(t *testing.T) {
 
 	testPidFileLocation := "/tmp/temptesting.pid"
+	defer os.Remove(testPidFileLocation)
 
 	file, err := os.Create(testPidFileLocation)
 	if err != nil {
@@ -35,4 +37,21 @@ func Test_stopDaemon_invalid_pid(t *testing.T) {
 	err = stopDaemon(testPidFileLocation)
 
 	compareAndShout(t, "Invalid PID found in "+testPidFileLocation, err.Error())
+}
+
+func Test_stopDaemon_normal(t *testing.T) {
+
+	testPidFileLocation := "/tmp/temptesting.pid"
+	defer os.Remove(testPidFileLocation)
+
+	cmd := exec.Command("sleep", "30")
+	cmd.Start()
+	savePID(cmd.Process.Pid, testPidFileLocation)
+
+	err := stopDaemon(testPidFileLocation)
+
+	if err != nil {
+		t.Error("Expecting nil \ngot\n", err)
+	}
+
 }


### PR DESCRIPTION
Allow users to apply flag "-d" to run Rediseen in background, and provide command "stop" to stop Rediseen running in background.

Implemented by storing the PID of the Rediseen process in a file (using os.TempDir() for default PID file location, as it's safer and can ensure feature works on all operating platforms). Users are also allowed to specify "-pidfile" if they want to have a different location for the PID file, or they want to run multiple Rediseen instances.
