### PR TITLE
New Feature: list keys which match pattern to expose, by logical DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,20 +147,20 @@ A sample response follows below
 
 ```
 {
-    count: 3,
-    total: 3,
-    keys: [
+    "count": 3,
+    "total": 3,
+    "keys": [
         {
-            key: "key:1",
-            type: "string"
+            "key": "key:1",
+            "type": "string"
         },
         {
-            key: "key:5",
-            type: "hash"
+            "key": "key:5",
+            "type": "hash"
         },
         {
-            key: "key:100",
-            type: "zset"
+            "key": "key:100",
+            "type": "zset"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ export REDISEEN_KEY_PATTERN_EXPOSED="^key:([0-9a-z]+)"
 rediseen start
 ```
 
-Now you should be able to query against the database, like `http://localhost:8000/0/key:1` (say you
-have a key named `key:1` set in your Redis database).
+Now you should be able to query against the database, like `http://localhost:8000/0` or `http://localhost:8000/0/key:1`
+(say you have a key named `key:1` set in your Redis database).
 
 For more details, please refer to the rest of this README documentation.
 
@@ -120,6 +120,7 @@ rediseen start
 ```
 
 Then you can access the service at
+- `http://<your server address>:<REDISEEN_PORT>/<redis DB>`
 - `http://<your server address>:<REDISEEN_PORT>/<redis DB>/<key>`
 - `http://<your server address>:<REDISEEN_PORT>/<redis DB>/<key>/<index or value or member>`
 
@@ -136,7 +137,36 @@ rediseen stop
 
 ### 2.4 How to Consume the Service
 
-#### 2.4.1 `/<redis DB>/<key>`
+#### 2.4.1 `/<redis DB>`
+
+This endpoint will return response in which you can get
+- the number of keys which are exposed
+- keys exposed and their types (only up to 1000 keys will be showed)
+
+A sample response follow below
+
+```json
+{
+    count: 3,
+    total: 3,
+    keys: [
+        {
+            key: "key:1",
+            type: "string"
+        },
+        {
+            key: "key:5",
+            type: "hash"
+        },
+        {
+            key: "key:100",
+            type: "zset"
+        }
+    ]
+}
+```
+
+#### 2.4.2 `/<redis DB>/<key>`
 
 | Data Type | Underlying Redis Command |
 | --- | --- |
@@ -147,7 +177,7 @@ rediseen stop
 | ZSET   | `ZRANGE(key, 0, -1)` |
 
 
-#### 2.4.2 `/<redis DB>/<key>/<index or value or member>`
+#### 2.4.3 `/<redis DB>/<key>/<index or value or member>`
 
 | Data Type | Usage | Return Value |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This endpoint will return response in which you can get
 
 A sample response follow below
 
-```json
+```
 {
     count: 3,
     total: 3,

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This endpoint will return response in which you can get
 - the number of keys which are exposed
 - keys exposed and their types (only up to 1000 keys will be showed)
 
-A sample response follow below
+A sample response follows below
 
 ```
 {

--- a/services.go
+++ b/services.go
@@ -63,9 +63,9 @@ func service(res http.ResponseWriter, req *http.Request) {
 	log.Printf("Request Path: '%s'\n", req.URL.Path)
 	arguments := strings.Split(req.URL.Path, "/")
 
-	if strings.HasSuffix(req.URL.Path, "/") || len(arguments) < 3 {
+	if strings.HasSuffix(req.URL.Path, "/") || len(arguments) < 2 {
 		res.WriteHeader(http.StatusBadRequest)
-		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /db/key, /db/key/index, or /db/key/field"})
+		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /db, /db/key, /db/key/index, or /db/key/field"})
 		res.Write(js)
 		return
 	}
@@ -76,19 +76,25 @@ func service(res http.ResponseWriter, req *http.Request) {
 
 	rawDb = arguments[1]
 
-	// deal with situation where key contains "/"
-	if len(arguments) == 3 {
-		key = arguments[2]
-	} else {
-		key, index = parseKeyAndIndex(strings.Join(arguments[2:], "/"))
-	}
-
 	db, err := strconv.Atoi(rawDb)
 	if err != nil {
 		res.WriteHeader(http.StatusBadRequest)
 		js, _ = json.Marshal(types.ErrorType{Error: "Provide an integer for DB"})
 		res.Write(js)
 		return
+	}
+
+	client := conn.Client(db)
+	defer client.Close()
+
+	// deal with situation where key contains "/"
+	if len(arguments) == 2 {
+		listKeysByDb(client, res)
+		return
+	} else if len(arguments) == 3 {
+		key = arguments[2]
+	} else {
+		key, index = parseKeyAndIndex(strings.Join(arguments[2:], "/"))
 	}
 
 	if !dbCheck(db) {
@@ -104,9 +110,6 @@ func service(res http.ResponseWriter, req *http.Request) {
 		res.Write(js)
 		return
 	}
-
-	client := conn.Client(db)
-	defer client.Close()
 
 	// Check if key exists, meanwhile check Redis connection
 	keyExists, err := client.Exists(key).Result()

--- a/services.go
+++ b/services.go
@@ -87,6 +87,13 @@ func service(res http.ResponseWriter, req *http.Request) {
 	client := conn.Client(db)
 	defer client.Close()
 
+	if !dbCheck(db) {
+		res.WriteHeader(http.StatusForbidden)
+		js, _ = json.Marshal(types.ErrorType{Error: fmt.Sprintf("DB %d is not exposed", db)})
+		res.Write(js)
+		return
+	}
+
 	// deal with situation where key contains "/"
 	if len(arguments) == 2 {
 		listKeysByDb(client, res)
@@ -95,13 +102,6 @@ func service(res http.ResponseWriter, req *http.Request) {
 		key = arguments[2]
 	} else {
 		key, index = parseKeyAndIndex(strings.Join(arguments[2:], "/"))
-	}
-
-	if !dbCheck(db) {
-		res.WriteHeader(http.StatusForbidden)
-		js, _ = json.Marshal(types.ErrorType{Error: fmt.Sprintf("DB %d is not exposed", db)})
-		res.Write(js)
-		return
 	}
 
 	if !keyPatternCheck(key) {

--- a/services_test.go
+++ b/services_test.go
@@ -114,6 +114,8 @@ func Test_service_non_existent_key(t *testing.T) {
 	compareAndShout(t, expectedError, result.Error)
 }
 
+// Check listing-keys feature
+// Taking keys which are NOT exposed into consideration as well (they should NOT be counted or returned)
 func Test_service_list_keys_by_db_1(t *testing.T) {
 
 	mr, _ := miniredis.Run()
@@ -164,6 +166,10 @@ func Test_service_list_keys_by_db_1(t *testing.T) {
 	}
 }
 
+// Check listing-keys feature
+// Check the situation where more than 1000 keys are exposed
+// `Total` should be the total number, BUT only up to 1000 keys should be returned.
+// `Count` should be up to 1000 as well
 func Test_service_list_keys_by_db_2(t *testing.T) {
 
 	mr, _ := miniredis.Run()

--- a/services_test.go
+++ b/services_test.go
@@ -420,7 +420,7 @@ func Test_service_list_keys_for_db_without_access(t *testing.T) {
 	defer s.Close()
 
 	// env var set for the test is REDISEEN_DB_EXPOSED=0-5
-	for _, db := range []int{6, 10, 100} {
+	for db := 6; db <= 100; db++ {
 		res, _ := http.Get(s.URL + fmt.Sprintf("/%v", db))
 
 		expectedCode := 403

--- a/services_test.go
+++ b/services_test.go
@@ -379,6 +379,7 @@ func Test_service_string_type_with_slash_and_backtick_in_key(t *testing.T) {
 	compareAndShout(t, "hi", result.Value)
 }
 
+// Validate if listing-keys feature returns 200 if the DB in client request IS exposed
 func Test_service_list_keys_for_db_with_access(t *testing.T) {
 	mr, _ := miniredis.Run()
 	defer mr.Close()
@@ -408,6 +409,7 @@ func Test_service_list_keys_for_db_with_access(t *testing.T) {
 	}
 }
 
+// Validate if listing-keys feature returns 403 if the DB in client request is NOT exposed
 func Test_service_list_keys_for_db_without_access(t *testing.T) {
 	mr, _ := miniredis.Run()
 	defer mr.Close()

--- a/types/types.go
+++ b/types/types.go
@@ -10,3 +10,16 @@ type ResponseType struct {
 type ErrorType struct {
 	Error string `json:"error"`
 }
+
+// KeyInfoType acts as the JSON template for element in KeyListType
+type KeyInfoType struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+}
+
+// KeyListType acts as the JSON template for API response (successful calls)
+type KeyListType struct {
+	Count int           `json:"count"`
+	Total int           `json:"total"`
+	Keys  []KeyInfoType `json:"keys"`
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const rediseenVersion = "1.1.2-dev"
+const rediseenVersion = "1.2.0-dev"


### PR DESCRIPTION
- Users can list the keys (exposed) in a specific logical DB by access `http://<ip>:<port>/<logical DB>`. Response will be like

```json
{
    "count": 3,
    "total": 3,
    "keys": [
        {
            "key": "key:1",
            "type": "string"
        },
        {
            "key": "key:5",
            "type": "hash"
        },
        {
            "key": "key:100",
            "type": "zset"
        }
    ]
}
```
- Only up to 1000 keys will be shown in the response (`count` field will be up to 1000). But `total` field in the response will be the actual number.
- Logical-DB-level access control, i.e., users can only list keys for the DBs which are exposed by `REDISEEN_DB_EXPOSED`