### PR TITLE
Use jq in integration test to do more strict check on JSON output

### DIFF
--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -44,6 +44,7 @@ jobs:
         REDISEEN_DB_EXPOSED: 0-5
       run: |
         sudo apt-get install redis-tools
+        sudo apt-get install jq
 
         check_by_grep_output () {
             # $1: URL to Curl
@@ -51,6 +52,22 @@ jobs:
             echo Calling: $1
             echo Expecting: $2
             if curl -s $1 | grep "$2"; then
+                echo OK
+            else
+                echo "You're on fire"
+                exit 1
+            fi
+            echo
+        }
+        
+        check_by_jq_field () {
+            # $1: URL to Curl
+            # $2: field in the JSON response to check 
+            # $3: value expected for the field specified
+            echo Calling: $1
+            echo Checking Field: $2
+            echo Expecting Field: $3
+            if curl -s '$1' | jq '.$2'; then
                 echo OK
             else
                 echo "You're on fire"

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -85,6 +85,7 @@ jobs:
 
         check_by_grep_output http://localhost:9000 "Usage: /db, /db/key, /db/key/index, or /db/key/field"
         check_by_grep_output http://localhost:9000/0/key:1/1/1 "Usage: /db, /db/key, /db/key/index, or /db/key/field"
+        check_by_jq_field http://localhost:9000 error "Usage: /db, /db/key, /db/key/index, or /db/key/field"
         check_by_grep_output http://localhost:9000/0 "count"
         check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist"
         check_by_grep_output http://localhost:9000/0/key:1/1 "Key provided does not exist"

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -64,17 +64,20 @@ jobs:
             # $1: URL to Curl
             # $2: field in the JSON response to check 
             # $3: value expected for the field specified
+
             echo Calling: $1
             echo Checking Field: $2
             echo Expecting Field: $3
-            if curl -s '$1' | jq '.$2'; then
+
+            RESULT=$(curl -s $1 | jq -r '.'$2)
+            if [ $RESULT == $3 ]; then
                 echo OK
             else
                 echo "You're on fire"
                 exit 1
             fi
             echo
-        }
+        } 
 
         go build -v .
 

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -90,10 +90,10 @@ jobs:
         check_by_grep_output http://localhost:9000/0 "count"
         check_by_jq_field http://localhost:9000/0 count "0"
         check_by_jq_field http://localhost:9000/0 total "0"
-        check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist"
-        check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist"
-        check_by_grep_output http://localhost:9000/0/key:1/1 "Key provided does not exist"
-        check_by_jq_field http://localhost:9000/0/key:1/1 error "Key provided does not exist"
+        check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist."
+        check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist."
+        check_by_grep_output http://localhost:9000/0/key:1/1 "Key provided does not exist."
+        check_by_jq_field http://localhost:9000/0/key:1/1 error "Key provided does not exist."
         check_by_jq_field http://localhost:9000/0/no_access_key error "Key pattern is forbidden from access"
         check_by_grep_output http://localhost:9000/6 "DB 6 is not exposed"
         check_by_jq_field http://localhost:9000/6 error "DB 6 is not exposed"
@@ -125,12 +125,12 @@ jobs:
         check_by_grep_output http://localhost:9000/0/key:3/2 "ENJOY"
 
         echo "del key:1" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
-        check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist"
+        check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist."
 
         echo "del key:2" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
-        check_by_grep_output http://localhost:9000/0/key:2 "Key provided does not exist"
+        check_by_grep_output http://localhost:9000/0/key:2 "Key provided does not exist."
 
         echo "del key:3" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
-        check_by_grep_output http://localhost:9000/0/key:3 "Key provided does not exist"
+        check_by_grep_output http://localhost:9000/0/key:3 "Key provided does not exist."
         
         ./rediseen stop    

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -69,9 +69,10 @@ jobs:
             echo Checking Field: $2
             echo Expecting Field: $3
 
-            RESULT=$(curl -s $1 | jq -r '.'$2)
+            OUTPUT=$(curl -s $1)
+            echo $OUTPUT
+            RESULT=$(echo $OUTPUT | jq -r '.'$2)
             if [ "$RESULT" == "$3" ]; then
-                echo $RESULT
                 echo OK
             else
                 echo "You're on fire"

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -71,6 +71,7 @@ jobs:
 
             RESULT=$(curl -s $1 | jq -r '.'$2)
             if [ "$RESULT" == "$3" ]; then
+                echo $RESULT
                 echo OK
             else
                 echo "You're on fire"
@@ -90,15 +91,23 @@ jobs:
         check_by_jq_field http://localhost:9000/0 count "0"
         check_by_jq_field http://localhost:9000/0 total "0"
         check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist"
+        check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist"
         check_by_grep_output http://localhost:9000/0/key:1/1 "Key provided does not exist"
-        check_by_grep_output http://localhost:9000/0/no_access_key "Key pattern is forbidden from access"
+        check_by_jq_field http://localhost:9000/0/key:1/1 error "Key provided does not exist"
+        check_by_jq_field http://localhost:9000/0/no_access_key error "Key pattern is forbidden from access"
         check_by_grep_output http://localhost:9000/6 "DB 6 is not exposed"
+        check_by_jq_field http://localhost:9000/6 error "DB 6 is not exposed"
         check_by_grep_output http://localhost:9000/6/key:1 "DB 6 is not exposed"
+        check_by_jq_field http://localhost:9000/6/key:1 error "DB 6 is not exposed"
 
         echo "set key:1 Rediseen" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_grep_output http://localhost:9000/0/key:1 "Rediseen"
         check_by_grep_output http://localhost:9000/0/key:1 "string"
+        check_by_jq_field http://localhost:9000/6/key:1 value "Rediseen"
+        check_by_jq_field http://localhost:9000/6/key:1 type "string"
         check_by_grep_output http://localhost:9000/0/key:1/2 "d"
+        check_by_jq_field http://localhost:9000/6/key:1/2 value "d"
+        check_by_jq_field http://localhost:9000/6/key:1/2 type "string"
 
         echo "hset key:2 year 2019" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         echo "hset key:2 project rediseen" | redis-cli -p ${{ job.services.redis.ports['6379'] }}

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -70,7 +70,7 @@ jobs:
             echo Expecting Field: $3
 
             RESULT=$(curl -s $1 | jq -r '.'$2)
-            if [ $RESULT == $3 ]; then
+            if [ "$RESULT" == "$3" ]; then
                 echo OK
             else
                 echo "You're on fire"
@@ -87,6 +87,8 @@ jobs:
         check_by_grep_output http://localhost:9000/0/key:1/1/1 "Usage: /db, /db/key, /db/key/index, or /db/key/field"
         check_by_jq_field http://localhost:9000 error "Usage: /db, /db/key, /db/key/index, or /db/key/field"
         check_by_grep_output http://localhost:9000/0 "count"
+        check_by_jq_field http://localhost:9000/0 count "0"
+        check_by_jq_field http://localhost:9000/0 total "0"
         check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist"
         check_by_grep_output http://localhost:9000/0/key:1/1 "Key provided does not exist"
         check_by_grep_output http://localhost:9000/0/no_access_key "Key pattern is forbidden from access"

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -115,6 +115,11 @@ jobs:
         check_by_grep_output http://localhost:9000/0/key:2/year "hash"
         check_by_grep_output http://localhost:9000/0/key:2/year "2019"
         check_by_grep_output http://localhost:9000/0/key:2/project "rediseen"
+        check_by_jq_field http://localhost:9000/0/key:2 type "hash"
+        check_by_jq_field http://localhost:9000/0/key:2/year type "hash"
+        check_by_jq_field http://localhost:9000/0/key:2/year value "2019"
+        check_by_jq_field http://localhost:9000/0/key:2/project type "hash"
+        check_by_jq_field http://localhost:9000/0/key:2/project value "rediseen"
         
         echo "lpush key:3 github" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         echo "lpush key:3 coding" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
@@ -123,14 +128,18 @@ jobs:
         check_by_grep_output http://localhost:9000/0/key:3/0 "coding"
         check_by_grep_output http://localhost:9000/0/key:3/1 "github"
         check_by_grep_output http://localhost:9000/0/key:3/2 "ENJOY"
+        check_by_jq_field http://localhost:9000/0/key:3 type "list"
 
         echo "del key:1" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_grep_output http://localhost:9000/0/key:1 "Key provided does not exist."
+        check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist."
 
         echo "del key:2" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_grep_output http://localhost:9000/0/key:2 "Key provided does not exist."
+        check_by_jq_field http://localhost:9000/0/key:2 error "Key provided does not exist."
 
         echo "del key:3" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_grep_output http://localhost:9000/0/key:3 "Key provided does not exist."
+        check_by_jq_field http://localhost:9000/0/key:3 error "Key provided does not exist."
         
         ./rediseen stop    

--- a/.github/workflows/rediseen_integration_Test.yml
+++ b/.github/workflows/rediseen_integration_Test.yml
@@ -103,11 +103,11 @@ jobs:
         echo "set key:1 Rediseen" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_grep_output http://localhost:9000/0/key:1 "Rediseen"
         check_by_grep_output http://localhost:9000/0/key:1 "string"
-        check_by_jq_field http://localhost:9000/6/key:1 value "Rediseen"
-        check_by_jq_field http://localhost:9000/6/key:1 type "string"
+        check_by_jq_field http://localhost:9000/0/key:1 value "Rediseen"
+        check_by_jq_field http://localhost:9000/0/key:1 type "string"
         check_by_grep_output http://localhost:9000/0/key:1/2 "d"
-        check_by_jq_field http://localhost:9000/6/key:1/2 value "d"
-        check_by_jq_field http://localhost:9000/6/key:1/2 type "string"
+        check_by_jq_field http://localhost:9000/0/key:1/2 value "d"
+        check_by_jq_field http://localhost:9000/0/key:1/2 type "string"
 
         echo "hset key:2 year 2019" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         echo "hset key:2 project rediseen" | redis-cli -p ${{ job.services.redis.ports['6379'] }}


### PR DESCRIPTION
Earlier I'm only considering JSON output from API as a string and use `grep` to check.

But  we can use `jq` to check field by field, which is much better (avoid incorrect check + can check if specific field is present).