### PR TITLE
Support exposing results of `INFO` command

### DIFF
--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -116,10 +116,11 @@ jobs:
         check_by_jq_field http://localhost:9000/0/key:3 error "Key provided does not exist."
 
         curl -s http://localhost:9000/info
-        curl -s http://localhost:9000/server
-        curl -s http://localhost:9000/clients
-        curl -s http://localhost:9000/cluster
-        curl -s http://localhost:9000/cpu
+        curl -s http://localhost:9000/info/server
+        curl -s http://localhost:9000/info/clients
+        curl -s http://localhost:9000/info/cluster
+        curl -s http://localhost:9000/info/cpu
+        curl -s http://localhost:9000/info/invalidSection
         
         ./rediseen stop
 

--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -129,5 +129,6 @@ jobs:
 
         ./rediseen -d start
         check_by_jq_field http://localhost:9000/0 error "unauthorized"
+        check_by_jq_field http://localhost:9000/info error "unauthorized"
         ./rediseen stop
 

--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -74,8 +74,8 @@ jobs:
 
         ./rediseen -d start
 
-        check_by_jq_field http://localhost:9000 error "Usage: /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
-        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000 error "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
         check_by_jq_field http://localhost:9000/0 count "0"
         check_by_jq_field http://localhost:9000/0 total "0"
         check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist."

--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -114,6 +114,12 @@ jobs:
 
         echo "del key:3" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_jq_field http://localhost:9000/0/key:3 error "Key provided does not exist."
+
+        curl -s http://localhost:9000/info
+        curl -s http://localhost:9000/server
+        curl -s http://localhost:9000/clients
+        curl -s http://localhost:9000/cluster
+        curl -s http://localhost:9000/cpu
         
         ./rediseen stop
 

--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -92,8 +92,8 @@ jobs:
 
         ./rediseen -d start
 
-        check_by_jq_field http://localhost:9000 error "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
-        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000 error "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
         check_by_jq_field http://localhost:9000/0 count "0"
         check_by_jq_field http://localhost:9000/0 total "0"
         check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist."

--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -48,6 +48,24 @@ jobs:
       run: |
         sudo apt-get install redis-tools
         sudo apt-get install jq
+
+        check_by_status_code () {
+          # $1: URL to Curl
+          # $2: expected status code
+
+          echo Calling: $1
+          echo Expecting status code: $2
+
+          RESULT=$(curl -s -o /dev/null -w "%{http_code}" $1)
+          echo $RESULT
+          if [ "$RESULT" == "$2" ]; then
+              echo OK
+          else
+              echo "You're on fire"
+              exit 1
+          fi
+          echo
+        }
         
         check_by_jq_field () {
             # $1: URL to Curl
@@ -68,7 +86,7 @@ jobs:
                 exit 1
             fi
             echo
-        } 
+        }
 
         go build -v .
 
@@ -115,12 +133,12 @@ jobs:
         echo "del key:3" | redis-cli -p ${{ job.services.redis.ports['6379'] }}
         check_by_jq_field http://localhost:9000/0/key:3 error "Key provided does not exist."
 
-        curl -s http://localhost:9000/info
-        curl -s http://localhost:9000/info/server
-        curl -s http://localhost:9000/info/clients
-        curl -s http://localhost:9000/info/cluster
-        curl -s http://localhost:9000/info/cpu
-        curl -s http://localhost:9000/info/invalidSection
+        check_by_status_code http://localhost:9000/info 200
+        check_by_status_code http://localhost:9000/info/server 200
+        check_by_status_code http://localhost:9000/info/clients 200
+        check_by_status_code http://localhost:9000/info/cluster 200
+        check_by_status_code http://localhost:9000/info/cpu 200
+        check_by_status_code http://localhost:9000/info/invalidSection 400
         
         ./rediseen stop
 
@@ -130,5 +148,8 @@ jobs:
         ./rediseen -d start
         check_by_jq_field http://localhost:9000/0 error "unauthorized"
         check_by_jq_field http://localhost:9000/info error "unauthorized"
+
+        check_by_status_code http://localhost:9000/0 401
+        check_by_status_code http://localhost:9000/info 401
         ./rediseen stop
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Start a REST-like API service for your Redis database, without writing a single 
 
 - Allows clients to query records in Redis database via HTTP conveniently
 - Allows you to specify which logical DB(s) to expose, and what key patterns to expose
-- Expose results of redis `INFO` command in nice way, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
+- Expose results of redis `INFO` command in nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
 - Supports API Key authentication
 
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2), and built on shoulder of [go-redis/redis
@@ -251,11 +251,11 @@ A sample response follows below
 
 #### 2.4.4 `/info`
 
-It returns (part of) the results from Redis `INFO` command as a nice-formatted JSON object.
+It returns (part of) the results from Redis `INFO` command as a nicely-formatted JSON object.
 
 #### 2.4.5 `/info/<info_section>`
 
-It returns (part of) the results from Redis `INFO <SECTION>` command as a nice-formatted JSON object.
+It returns (part of) the results from Redis `INFO <SECTION>` command as a nicely-formatted JSON object.
 
 Currently `info_section` supports values `server`, `clients`, `replication`, `cpu`, and `cluster`.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 Start a REST-like API service for your Redis database, without writing a single line of code.
 
+- Allows clients to query records in Redis database via HTTP conveniently
+- Allows you to specify which logical DB(s) to expose, and what key patterns to expose
+- Expose results of redis `INFO` command in nice way, so you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard as well.
+- Supports API Key authentication
+
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2), and built on shoulder of [go-redis/redis
 ](https://github.com/go-redis/redis))
 
@@ -39,7 +44,8 @@ export REDISEEN_KEY_PATTERN_EXPOSED="^key:([0-9a-z]+)"
 rediseen start
 ```
 
-Now you should be able to query against your Redis database, like `http://localhost:8000/0` or `http://localhost:8000/0/key:1`
+Now you should be able to query against your Redis database, like `http://localhost:8000/0`, `http://localhost:8000/0/key:1`
+or `http://localhost:8000/info`
 (say you have keys `key:1` (string) and `key:2` (hash) set in your logical DB `0`). Sample responses follow below
 
 ```bash
@@ -67,6 +73,29 @@ GET /0/key:1
 {
     "type": "string",
     "value": "rediseen"
+}
+```
+
+```bash
+GET /info
+
+{
+    Server: {
+        redis_version: "5.0.6",
+        ...
+    },
+    Clients: {
+        ...
+    },
+    Replication: {
+        ...
+    },
+    CPU: {
+        ...
+    },
+    Cluster: {
+        ...
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Start a REST-like API service for your Redis database, without writing a single 
 
 - Allows clients to query records in Redis database via HTTP conveniently
 - Allows you to specify which logical DB(s) to expose, and what key patterns to expose
-- Expose results of redis `INFO` command in nice way, so you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard as well.
+- Expose results of redis `INFO` command in nice way, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
 - Supports API Key authentication
 
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2), and built on shoulder of [go-redis/redis
@@ -44,8 +44,8 @@ export REDISEEN_KEY_PATTERN_EXPOSED="^key:([0-9a-z]+)"
 rediseen start
 ```
 
-Now you should be able to query against your Redis database, like `http://localhost:8000/0`, `http://localhost:8000/0/key:1`
-or `http://localhost:8000/info`
+Now you should be able to query against your Redis database, like `http://localhost:8000/0`, `http://localhost:8000/0/key:1`,
+`http://localhost:8000/info` or `http://localhost:8000/info/server`
 (say you have keys `key:1` (string) and `key:2` (hash) set in your logical DB `0`). Sample responses follow below
 
 ```bash
@@ -90,12 +90,14 @@ GET /info
     Replication: {
         ...
     },
-    CPU: {
-        ...
-    },
-    Cluster: {
-        ...
-    }
+    ...
+}
+
+GET /info/server
+
+{
+    redis_version: "5.0.6",
+    ...
 }
 ```
 
@@ -244,6 +246,14 @@ A sample response follows below
 | SET    | `/<redis DB>/<key>/<member>` | if `<member>` is member of the set |
 | HASH   | `/<redis DB>/<key>/<field>` | value of hash `<field>` in the hash |
 | ZSET   | `/<redis DB>/<key>/<memeber>` | index of `<member>` in the sorted set |
+
+#### 2.4.4 `/info`
+
+It returns (part of) the results from Redis `INFO` command as a nice-formatted JSON object.
+
+#### 2.4.5 `/info/<info section>`
+
+It returns (part of) the results from Redis `INFO <SECTION>` command as a nice-formatted JSON object.
 
 
 ## 3. Authentication

--- a/README.md
+++ b/README.md
@@ -253,9 +253,11 @@ A sample response follows below
 
 It returns (part of) the results from Redis `INFO` command as a nice-formatted JSON object.
 
-#### 2.4.5 `/info/<info section>`
+#### 2.4.5 `/info/<info_section>`
 
 It returns (part of) the results from Redis `INFO <SECTION>` command as a nice-formatted JSON object.
+
+Currently `info_section` supports values `server`, `clients`, `replication`, `cpu`, and `cluster`.
 
 
 ## 3. Authentication

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Start a REST-like API service for your Redis database, without writing a single 
 
 - Allows clients to query records in Redis database via HTTP conveniently
 - Allows you to specify which logical DB(s) to expose, and what key patterns to expose
-- Expose results of redis `INFO` command in nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
+- Expose results of [redis `INFO` command](https://redis.io/commands/info) in nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
 - Supports API Key authentication
 
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2), and built on shoulder of [go-redis/redis
@@ -251,11 +251,11 @@ A sample response follows below
 
 #### 2.4.4 `/info`
 
-It returns (part of) the results from Redis `INFO` command as a nicely-formatted JSON object.
+It returns (part of) the results from [Redis `INFO` command](https://redis.io/commands/info) as a nicely-formatted JSON object.
 
 #### 2.4.5 `/info/<info_section>`
 
-It returns (part of) the results from Redis `INFO <SECTION>` command as a nicely-formatted JSON object.
+It returns (part of) the results from [Redis `INFO <SECTION>` command](https://redis.io/commands/info) as a nicely-formatted JSON object.
 
 Currently `info_section` supports values `server`, `clients`, `replication`, `cpu`, and `cluster`.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ GET /info
     },
     ...
 }
+```
 
+```bash
 GET /info/server
 
 {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Start a REST-like API service for your Redis database, without writing a single 
 
 - Allows clients to query records in Redis database via HTTP conveniently
 - Allows you to specify which logical DB(s) to expose, and what key patterns to expose
-- Expose results of [redis `INFO` command](https://redis.io/commands/info) in nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
+- Expose results of [Redis `INFO` command](https://redis.io/commands/info) in nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
 - Supports API Key authentication
 
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2), and built on shoulder of [go-redis/redis

--- a/conn/client.go
+++ b/conn/client.go
@@ -147,8 +147,14 @@ func (client *ExtendedClient) Retrieve(res http.ResponseWriter, key string, inde
 	res.Write(js)
 }
 
-func (client *ExtendedClient) RedisInfo() (types.Info, error) {
-	infoResult, err := client.RedisClient.Info().Result()
+func (client *ExtendedClient) RedisInfo(section string) (types.Info, error) {
+	var infoResult string
+	var err error
+	if section == "" {
+		infoResult, err = client.RedisClient.Info().Result()
+	} else {
+		infoResult, err = client.RedisClient.Info(section).Result()
+	}
 	if err != nil {
 		return types.Info{}, err
 	}
@@ -183,7 +189,7 @@ func (client *ExtendedClient) RedisInfo() (types.Info, error) {
 		ConfigFile:      mapResult["config_file"],
 	}
 
-	result.Client = types.InfoClient{
+	result.Clients = types.InfoClients{
 		ConnectedClients: mapResult["connected_clients"],
 		BlockedClients:   mapResult["blocked_clients"],
 	}
@@ -201,6 +207,8 @@ func (client *ExtendedClient) RedisInfo() (types.Info, error) {
 		UsedCpuSysChildren:  mapResult["used_cpu_sys_children"],
 		UsedCpuUserChildren: mapResult["used_cpu_user_children"],
 	}
+
+	result.Cluster = types.InfoCluster{ClusterEnabled: mapResult["cluster_enabled"]}
 
 	return result, nil
 }

--- a/conn/client.go
+++ b/conn/client.go
@@ -147,10 +147,7 @@ func (client *ExtendedClient) Retrieve(res http.ResponseWriter, key string, inde
 	res.Write(js)
 }
 
-func (client *ExtendedClient) TransformRedisInfoToJson() (types.Info, error) {
-
-	var result types.Info
-
+func (client *ExtendedClient) RedisInfo() (types.Info, error) {
 	infoResult, err := client.RedisClient.Info().Result()
 	if err != nil {
 		return types.Info{}, err
@@ -158,16 +155,14 @@ func (client *ExtendedClient) TransformRedisInfoToJson() (types.Info, error) {
 
 	mapResult := make(map[string]string)
 	for _, kv := range strings.Split(infoResult, "\n") {
-		if len(kv) == 0 || string(kv[0]) == "#" || string(kv[0]) == "" {
+		values := strings.Split(kv, ":")
+		if len(values) != 2 {
 			continue
-		} else {
-			values := strings.Split(kv, ":")
-			if len(values) < 2 {
-				continue
-			}
-			mapResult[values[0]] = strings.TrimSpace(values[1])
 		}
+		mapResult[values[0]] = strings.TrimSpace(values[1])
 	}
+
+	var result types.Info
 
 	result.Server = types.InfoServer{
 		RedisVersion:    mapResult["redis_version"],

--- a/conn/client.go
+++ b/conn/client.go
@@ -146,3 +146,66 @@ func (client *ExtendedClient) Retrieve(res http.ResponseWriter, key string, inde
 	}
 	res.Write(js)
 }
+
+func (client *ExtendedClient) TransformRedisInfoToJson() (types.Info, error) {
+
+	var result types.Info
+
+	infoResult, err := client.RedisClient.Info().Result()
+	if err != nil {
+		return types.Info{}, err
+	}
+
+	mapResult := make(map[string]string)
+	for _, kv := range strings.Split(infoResult, "\n") {
+		if len(kv) == 0 || string(kv[0]) == "#" || string(kv[0]) == "" {
+			continue
+		} else {
+			values := strings.Split(kv, ":")
+			if len(values) < 2 {
+				continue
+			}
+			mapResult[values[0]] = strings.TrimSpace(values[1])
+		}
+	}
+
+	result.Server = types.InfoServer{
+		RedisVersion:    mapResult["redis_version"],
+		RedisBuildId:    mapResult["redis_build_id"],
+		RedisMode:       mapResult["redis_mode"],
+		Os:              mapResult["os"],
+		ArchBits:        mapResult["arch_bits"],
+		GccVersion:      mapResult["gcc_version"],
+		ProcessId:       mapResult["process_id"],
+		RunId:           mapResult["run_id"],
+		TcpPort:         mapResult["tcp_port"],
+		UptimeInSeconds: mapResult["uptime_in_seconds"],
+		UptimeInDays:    mapResult["uptime_in_days"],
+		Hz:              mapResult["hz"],
+		ConfiguredHz:    mapResult["configured_hz"],
+		LruClock:        mapResult["lru_clock"],
+		Executable:      mapResult["executable"],
+		ConfigFile:      mapResult["config_file"],
+	}
+
+	result.Client = types.InfoClient{
+		ConnectedClients: mapResult["connected_clients"],
+		BlockedClients:   mapResult["blocked_clients"],
+	}
+
+	result.Replication = types.InfoReplication{
+		Role:            mapResult["role"],
+		ConnectedSlaves: mapResult["connected_slaves"],
+		MasterReplId:    mapResult["master_replid"],
+		MasterReplId2:   mapResult["master_replid2"],
+	}
+
+	result.Cpu = types.InfoCpu{
+		UsedCpuSys:          mapResult["used_cpu_sys"],
+		UsedCpuUser:         mapResult["used_cpu_user"],
+		UsedCpuSysChildren:  mapResult["used_cpu_sys_children"],
+		UsedCpuUserChildren: mapResult["used_cpu_user_children"],
+	}
+
+	return result, nil
+}

--- a/conn/client.go
+++ b/conn/client.go
@@ -201,7 +201,7 @@ func (client *ExtendedClient) RedisInfo(section string) (types.Info, error) {
 		MasterReplId2:   mapResult["master_replid2"],
 	}
 
-	result.Cpu = types.InfoCpu{
+	result.CPU = types.InfoCpu{
 		UsedCpuSys:          mapResult["used_cpu_sys"],
 		UsedCpuUser:         mapResult["used_cpu_user"],
 		UsedCpuSysChildren:  mapResult["used_cpu_sys_children"],

--- a/service.go
+++ b/service.go
@@ -168,7 +168,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	if strings.HasSuffix(req.URL.Path, "/") || countArguments < 2 || countArguments > 4 {
 		res.WriteHeader(http.StatusBadRequest)
-		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
+		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
 		res.Write(js)
 		return
 	}
@@ -209,7 +209,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				js, _ = json.Marshal(info.Cluster)
 			default:
 				res.WriteHeader(http.StatusBadRequest)
-				js, _ = json.Marshal(types.ErrorType{Error: fmt.Sprintf("invalid section `%s` is given", section)})
+				js, _ = json.Marshal(types.ErrorType{Error: fmt.Sprintf("invalid section `%s` is given. Check /info for supported sections.", section)})
 			}
 		}
 		res.Write(js)

--- a/service.go
+++ b/service.go
@@ -182,7 +182,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if rawDb == "info" {
 		var section string
 		if countArguments == 3 {
-			section = arguments[2]
+			section = strings.ToLower(arguments[2])
 		}
 
 		var client conn.ExtendedClient
@@ -208,7 +208,8 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			case "cluster":
 				js, _ = json.Marshal(info.Cluster)
 			default:
-				js, _ = json.Marshal(types.ErrorType{Error: "invalid `section` is given"})
+				res.WriteHeader(http.StatusBadRequest)
+				js, _ = json.Marshal(types.ErrorType{Error: fmt.Sprintf("invalid section `%s` is given", section)})
 			}
 		}
 		res.Write(js)

--- a/service.go
+++ b/service.go
@@ -184,15 +184,32 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		if countArguments == 3 {
 			section = arguments[2]
 		}
+
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
+
 		info, err := client.RedisInfo(section)
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
 			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})
 		} else {
-			js, _ = json.Marshal(info)
+			switch section {
+			case "":
+				js, _ = json.Marshal(info)
+			case "server":
+				js, _ = json.Marshal(info.Server)
+			case "clients":
+				js, _ = json.Marshal(info.Clients)
+			case "replication":
+				js, _ = json.Marshal(info.Replication)
+			case "cpu":
+				js, _ = json.Marshal(info.CPU)
+			case "cluster":
+				js, _ = json.Marshal(info.Cluster)
+			default:
+				js, _ = json.Marshal(types.ErrorType{Error: "invalid `section` is given"})
+			}
 		}
 		res.Write(js)
 		return

--- a/service.go
+++ b/service.go
@@ -192,7 +192,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		info, err := client.RedisInfo(section)
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
-			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})
+			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting Redis Info. Details: " + err.Error()})
 		} else {
 			switch section {
 			case "":

--- a/service.go
+++ b/service.go
@@ -180,10 +180,14 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	rawDb = arguments[1]
 
 	if rawDb == "info" {
+		var section string
+		if countArguments == 3 {
+			section = arguments[2]
+		}
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
-		info, err := client.RedisInfo()
+		info, err := client.RedisInfo(section)
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
 			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})

--- a/service.go
+++ b/service.go
@@ -179,6 +179,23 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	rawDb = arguments[1]
 
+	if rawDb == "info" {
+		var client conn.ExtendedClient
+		client.Init(0)
+		defer client.RedisClient.Close()
+		info, err := client.RedisClient.Info().Result()
+		if err != nil {
+			res.WriteHeader(http.StatusInternalServerError)
+			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})
+			res.Write(js)
+		} else {
+			res.Header().Set("Content-Type", "text/html")
+			js, _ := json.Marshal(info)
+			res.Write(js)
+		}
+		return
+	}
+
 	db, err := strconv.Atoi(rawDb)
 	if err != nil {
 		res.WriteHeader(http.StatusBadRequest)

--- a/service.go
+++ b/service.go
@@ -168,7 +168,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	if strings.HasSuffix(req.URL.Path, "/") || countArguments < 2 || countArguments > 4 {
 		res.WriteHeader(http.StatusBadRequest)
-		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
+		js, _ = json.Marshal(types.ErrorType{Error: "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
 		res.Write(js)
 		return
 	}
@@ -183,13 +183,12 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
-		info, err := client.RedisClient.Info().Result()
+		info, err := client.TransformRedisInfoToJson()
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
 			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})
 			res.Write(js)
 		} else {
-			res.Header().Set("Content-Type", "text/html")
 			js, _ := json.Marshal(info)
 			res.Write(js)
 		}

--- a/service.go
+++ b/service.go
@@ -183,15 +183,14 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
-		info, err := client.TransformRedisInfoToJson()
+		info, err := client.RedisInfo()
 		if err != nil {
 			res.WriteHeader(http.StatusInternalServerError)
 			js, _ = json.Marshal(types.ErrorType{Error: "Exception while getting INFO" + err.Error()})
-			res.Write(js)
 		} else {
-			js, _ := json.Marshal(info)
-			res.Write(js)
+			js, _ = json.Marshal(info)
 		}
+		res.Write(js)
 		return
 	}
 

--- a/service_test.go
+++ b/service_test.go
@@ -415,7 +415,7 @@ func Test_service_wrong_usage(t *testing.T) {
 	defer s.Close()
 
 	expectedCode := 400
-	expectedError := "Usage: /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+	expectedError := "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
 	casesToTest := []string{"/0/", "/0/key:1/", "/0/key:1/1/", "/0/key:1/1/1", "/0/key:1/1/1/", "/0/key:1/1/1/1"}
 	var res *http.Response
 

--- a/service_test.go
+++ b/service_test.go
@@ -415,7 +415,7 @@ func Test_service_wrong_usage(t *testing.T) {
 	defer s.Close()
 
 	expectedCode := 400
-	expectedError := "Usage: /info, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+	expectedError := "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
 	casesToTest := []string{"/0/", "/0/key:1/", "/0/key:1/1/", "/0/key:1/1/1", "/0/key:1/1/1/", "/0/key:1/1/1/1"}
 	var res *http.Response
 

--- a/service_test.go
+++ b/service_test.go
@@ -1276,7 +1276,7 @@ func Test_api_key_authentication(t *testing.T) {
 	mr.Set("key:1", "hello")
 
 	os.Setenv("REDISEEN_API_KEY", "nopass")
-	defer os.Setenv("REDISEEN_REDIS_URI", "")
+	defer os.Setenv("REDISEEN_API_KEY", "")
 
 	var testService service
 	testService.loadConfigFromEnv()

--- a/types/types.go
+++ b/types/types.go
@@ -70,6 +70,6 @@ type Info struct {
 	Server      InfoServer
 	Clients     InfoClients
 	Replication InfoReplication
-	Cpu         InfoCpu
+	CPU         InfoCpu
 	Cluster     InfoCluster
 }

--- a/types/types.go
+++ b/types/types.go
@@ -43,7 +43,7 @@ type InfoServer struct {
 	ConfigFile      string `json:"config_file"`
 }
 
-type InfoClient struct {
+type InfoClients struct {
 	ConnectedClients string `json:"connected_clients"`
 	BlockedClients   string `json:"blocked_clients"`
 }
@@ -62,9 +62,14 @@ type InfoCpu struct {
 	UsedCpuUserChildren string `json:"used_cpu_user_children"`
 }
 
+type InfoCluster struct {
+	ClusterEnabled string `json:"cluster_enabled"`
+}
+
 type Info struct {
 	Server      InfoServer
-	Client      InfoClient
+	Clients     InfoClients
 	Replication InfoReplication
 	Cpu         InfoCpu
+	Cluster     InfoCluster
 }

--- a/types/types.go
+++ b/types/types.go
@@ -23,3 +23,48 @@ type KeyListType struct {
 	Total int           `json:"total"`
 	Keys  []KeyInfoType `json:"keys"`
 }
+
+type InfoServer struct {
+	RedisVersion    string `json:"redis_version"`
+	RedisBuildId    string `json:"redis_build_id"`
+	RedisMode       string `json:"redis_mode"`
+	Os              string `json:"os"`
+	ArchBits        string `json:"arch_bits"`
+	GccVersion      string `json:"gcc_version"`
+	ProcessId       string `json:"process_id"`
+	RunId           string `json:"run_id"`
+	TcpPort         string `json:"tcp_port"`
+	UptimeInSeconds string `json:"uptime_in_seconds"`
+	UptimeInDays    string `json:"uptime_in_days"`
+	Hz              string `json:"hz"`
+	ConfiguredHz    string `json:"configured_hz"`
+	LruClock        string `json:"lru_clock"`
+	Executable      string `json:"executable"`
+	ConfigFile      string `json:"config_file"`
+}
+
+type InfoClient struct {
+	ConnectedClients string `json:"connected_clients"`
+	BlockedClients   string `json:"blocked_clients"`
+}
+
+type InfoReplication struct {
+	Role            string `json:"role"`
+	ConnectedSlaves string `json:"connected_slaves"`
+	MasterReplId    string `json:"master_replid"`
+	MasterReplId2   string `json:"master_replid2"`
+}
+
+type InfoCpu struct {
+	UsedCpuSys          string `json:"used_cpu_sys"`
+	UsedCpuUser         string `json:"used_cpu_user"`
+	UsedCpuSysChildren  string `json:"used_cpu_sys_children"`
+	UsedCpuUserChildren string `json:"used_cpu_user_children"`
+}
+
+type Info struct {
+	Server      InfoServer
+	Client      InfoClient
+	Replication InfoReplication
+	Cpu         InfoCpu
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const rediseenVersion = "1.4.2-dev"
+const rediseenVersion = "2.0.0"


### PR DESCRIPTION
Users can now query Redis INFO (results of `INFO` command) via `/info` endpoint. This can help users check Redis DB status easily. Further, this enables users to use `Rediseen` as a connector between Redis and monitoring dashboard