### PR TITLE
Create PID file as ~/.rediseen/rediseen.pid if run in daemon mode

### DIFF
--- a/rediseen.go
+++ b/rediseen.go
@@ -13,15 +13,24 @@ import (
 	"strconv"
 )
 
-func getPidFilePath() string {
+func getPidFileDir() string {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}
-	return path.Join(userHomeDir, "rediseen.pid")
+	return path.Join(userHomeDir, ".rediseen")
+}
+
+func getPidFilePath() string {
+	return path.Join(getPidFileDir(), "rediseen.pid")
 }
 
 func savePID(pid int, fileForPid string) error {
+	pidFileDir := getPidFileDir()
+	if _, err := os.Stat(pidFileDir); os.IsNotExist(err) {
+		os.Mkdir(pidFileDir, 0766)
+	}
+
 	f, err := os.Create(fileForPid)
 	if err != nil {
 		return fmt.Errorf("unable to create PID file: %s", err.Error())


### PR DESCRIPTION
When run in daemon mode, instead of creating PID file `rediseen.pid` under `$HOME/`, create it under `$HOME/.rediseen/`