### PR TITLE
Add more Go versions in Unit/Integration Testing; Update Test for Go 1.15

### DIFF
--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         redisversion: [latest, 5.0.6, 4.0.14, 3.2.12, 2.8.23]
+        goversion: [1.12, 1.13, 1.14, 1.15]
 
     services:
       redis:
@@ -19,10 +20,10 @@ jobs:
           - 6379/tcp
 
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: ${{ matrix.goversion }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/rediseen_unit_test.yml
+++ b/.github/workflows/rediseen_unit_test.yml
@@ -8,12 +8,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+        goversion: [1.12, 1.13, 1.14, 1.15]
 
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: ${{ matrix.goversion }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
   
 env:
   - GO111MODULE=on REDISEEN_REDIS_URI="redis://:@localhost:6400" REDISEEN_KEY_PATTERN_EXPOSED="^key:[.]*" REDISEEN_TEST_MODE=true REDISEEN_DB_EXPOSED=0-5

--- a/service_test.go
+++ b/service_test.go
@@ -641,7 +641,7 @@ func Test_service_list_keys_by_db_2(t *testing.T) {
 
 	n := 2000
 	for i := 0; i < 2000; i++ {
-		mr.Set(fmt.Sprintf("key:%v", i), string(i))
+		mr.Set(fmt.Sprintf("key:%v", i), string(rune(i)))
 	}
 
 	originalRedisURI := os.Getenv("REDISEEN_REDIS_URI")
@@ -678,7 +678,7 @@ func Test_service_list_keys_by_db_key_type_list(t *testing.T) {
 
 	n := 2000
 	for i := 0; i < n; i++ {
-		mr.Lpush(fmt.Sprintf("key:%v", i), string(i))
+		mr.Lpush(fmt.Sprintf("key:%v", i), string(rune(i)))
 	}
 
 	originalRedisURI := os.Getenv("REDISEEN_REDIS_URI")
@@ -715,7 +715,7 @@ func Test_service_list_keys_by_db_key_type_hash(t *testing.T) {
 
 	n := 500
 	for i := 0; i < n; i++ {
-		mr.HSet(fmt.Sprintf("key:%v", i), string(i), string(i))
+		mr.HSet(fmt.Sprintf("key:%v", i), string((i)), string((i)))
 	}
 
 	originalRedisURI := os.Getenv("REDISEEN_REDIS_URI")

--- a/service_test.go
+++ b/service_test.go
@@ -715,7 +715,7 @@ func Test_service_list_keys_by_db_key_type_hash(t *testing.T) {
 
 	n := 500
 	for i := 0; i < n; i++ {
-		mr.HSet(fmt.Sprintf("key:%v", i), string((i)), string((i)))
+		mr.HSet(fmt.Sprintf("key:%v", i), string(rune(i)), string(rune(i)))
 	}
 
 	originalRedisURI := os.Getenv("REDISEEN_REDIS_URI")


### PR DESCRIPTION
- Now for unit/integrating testing, we test against Go 1.12, 1.13, 1.14, and 1.15
- Fix issue in test code which start to appear in Go 1.15 (reference: https://github.com/prometheus/prometheus/pull/7707). 