### PR TITLE
New Endpoint `/metrics` to Provide Prometheus-compatible Redis INFO Command Output

### DIFF
--- a/.github/workflows/rediseen_integration_test.yml
+++ b/.github/workflows/rediseen_integration_test.yml
@@ -93,13 +93,13 @@ jobs:
         sleep 3
 
         # Test incorrect usage
-        check_by_jq_field http://localhost:9000/wrong_usage/ error "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000/wrong_usage/ error "Usage: /info, /info/<info_section>, /metrics, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
         check_by_status_code http://localhost:9000/wrong_usage/ 400
 
         # Test index endpoint
         check_by_status_code http://localhost:9000 200
 
-        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+        check_by_jq_field http://localhost:9000/0/key:1/1/1 error "Usage: /info, /info/<info_section>, /metrics, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
         check_by_jq_field http://localhost:9000/0 count "0"
         check_by_jq_field http://localhost:9000/0 total "0"
         check_by_jq_field http://localhost:9000/0/key:1 error "Key provided does not exist."
@@ -155,6 +155,8 @@ jobs:
         check_by_status_code http://localhost:9000/info/CPU 200
 
         check_by_status_code http://localhost:9000/info/invalidSection 400
+
+        check_by_status_code http://localhost:9000/metrics 200
         
         ./rediseen stop
 
@@ -171,5 +173,6 @@ jobs:
         check_by_status_code http://localhost:9000/0 401
         check_by_status_code http://localhost:9000/info 401
         check_by_status_code http://localhost:9000/info/server 401
+        check_by_status_code http://localhost:9000/metrics 401
         ./rediseen stop
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Start a REST-like API service for your Redis database, without writing a single 
 - Allows clients to query records in Redis database via HTTP conveniently
 - Allows you to specify which logical DB(s) to expose, and what key patterns to expose
 - Expose results of [Redis `INFO` command](https://redis.io/commands/info) in a nice format, so **you can use `Rediseen` as a connector between your Redis DB and monitoring dashboard** as well.
+  Endpoint `/info` provides Redis `INFO` command output in JSON format, and endpoint `/metrics` provides Prometheus-compatible format.
 - Supports API Key authentication
 
 (Inspired by [sandman2](https://github.com/jeffknupp/sandman2); Built on shoulder of [go-redis/redis

--- a/conn/client_test.go
+++ b/conn/client_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/alicebob/miniredis"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -19,5 +20,32 @@ func Test_ClientPing(t *testing.T) {
 	err := ClientPing()
 	if err != nil {
 		t.Error("Not expecting error but got error")
+	}
+}
+
+func Test_parseInfoLine(t *testing.T) {
+	data := []string{
+		"used_memory:866520",
+		"redis_version:6.0.8",
+		"# CPU",
+		"used_memory_human:846.21K",
+		"db0:keys=1053522,expires=7,avg_ttl=257671496273",
+		"cmdstat_info:calls=2,usec=254,usec_per_call=127.00",
+		"executable:/data/redis-server",
+	}
+	expected := [][]string{
+		{"used_memory 866520"},
+		{},
+		{"# CPU"},
+		{},
+		{"db0_keys 1053522", "db0_expires 7", "db0_avg_ttl 257671496273"},
+		{"cmdstat_info_calls 2", "cmdstat_info_usec 254", "cmdstat_info_usec_per_call 127.00"},
+		{},
+	}
+
+	for i, x := range data {
+		if !reflect.DeepEqual(parseInfoLine(x), expected[i]) {
+			t.Error("Something is wrong")
+		}
 	}
 }

--- a/service.go
+++ b/service.go
@@ -210,8 +210,10 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
+
 		res.Header().Set("Content-Type", "text/plain")
-		infoMetrics, _ := client.RedisInfo("CPU", "prometheus")
+		infoMetrics, _ := client.RedisInfo("all", "prometheus")
+
 		res.Write(infoMetrics)
 		return
 	}

--- a/service.go
+++ b/service.go
@@ -206,13 +206,22 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		pathPart2, pathPart3 = parseKeyAndIndex(strings.Join(arguments[2:], "/"))
 	}
 
+	if pathPart1 == "metrics" {
+		var client conn.ExtendedClient
+		client.Init(0)
+		defer client.RedisClient.Close()
+		res.Header().Set("Content-Type", "text/plain")
+		infoMetrics, _ := client.RedisInfo("CPU", "prometheus")
+		res.Write(infoMetrics)
+		return
+	}
 	if pathPart1 == "info" {
 
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()
 
-		js, err := client.RedisInfo(pathPart2)
+		js, err := client.RedisInfo(pathPart2, "json")
 		if err != nil {
 			if strings.Contains(err.Error(), "invalid section") {
 				res.WriteHeader(http.StatusBadRequest)

--- a/service.go
+++ b/service.go
@@ -175,7 +175,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Type", "text/plain")
 		res.Write([]byte(strHeader))
 		res.Write([]byte("\n\n"))
-		res.Write([]byte("Available Endpoints:\n - /info\n - /info/<info_section>\n - /<db>\n - /<db>/<key>\n - /<db>/<key>/<index>\n - /<db>/<key>/<field>"))
+		res.Write([]byte("Available Endpoints:\n - /info\n - /info/<info_section>\n - /metrics (Prometheus-compatible)\n - /<db>\n - /<db>/<key>\n - /<db>/<key>/<index>\n - /<db>/<key>/<field>"))
 		return
 	}
 
@@ -184,7 +184,7 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		buffer := &bytes.Buffer{}
 		encoder := json.NewEncoder(buffer)
 		encoder.SetEscapeHTML(false)
-		encoder.Encode(types.ErrorType{Error: "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
+		encoder.Encode(types.ErrorType{Error: "Usage: /info, /info/<info_section>, /metrics, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"})
 		res.Write(buffer.Bytes())
 		return
 	}
@@ -217,8 +217,8 @@ func (c *service) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		res.Write(infoMetrics)
 		return
 	}
-	if pathPart1 == "info" {
 
+	if pathPart1 == "info" {
 		var client conn.ExtendedClient
 		client.Init(0)
 		defer client.RedisClient.Close()

--- a/service_test.go
+++ b/service_test.go
@@ -415,7 +415,7 @@ func Test_service_wrong_usage(t *testing.T) {
 	defer s.Close()
 
 	expectedCode := 400
-	expectedError := "Usage: /info, /info/<info_section>, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
+	expectedError := "Usage: /info, /info/<info_section>, /metrics, /<db>, /<db>/<key>, /<db>/<key>/<index>, or /<db>/<key>/<field>"
 	casesToTest := []string{"/0/", "/0/key:1/", "/0/key:1/1/", "/0/key:1/1/1", "/0/key:1/1/1/", "/0/key:1/1/1/1"}
 	var res *http.Response
 


### PR DESCRIPTION
- Literally all output from Redis `INFO` command will be included, other than lines whose value cannot be parsed into a float (like "*used_memory_rss_human:4.56M*" or "*redis_version:5.0.7*").
- Some lines being included may be "false negative", for example "redis_git_sha1:00000000", which is not making sense as a metric. So users are expected to be aware of what they are doing.
- Special lines like "*db0:keys=1053522,expires=7,avg_ttl=257671496273*" will be parsed into 3 lines ("*db0_keys 1053522*", "*db0_expires 7*", "*db0_avg_ttl 257671496273*")